### PR TITLE
Replace TODO packet rewrites

### DIFF
--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/PacketWrapperFactory.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/PacketWrapperFactory.java
@@ -3,6 +3,7 @@ package ac.grim.grimac.api.packet.types;
 import ac.grim.grimac.api.packet.types.client.play.*;
 import ac.grim.grimac.api.packet.types.event.PacketReceiveEvent;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
+import ac.grim.grimac.api.packet.util.vec.ImmutableVector3d;
 import ac.grim.grimac.api.packet.types.server.play.*;
 
 public interface PacketWrapperFactory {
@@ -23,6 +24,22 @@ public interface PacketWrapperFactory {
     ServerOpenHorseWindowPacket serverOpenHorseWindow(PacketSendEvent event);
 
     ServerWindowItemsPacket serverWindowItems(PacketSendEvent event);
+
+
+    ServerEntityMetadataPacket serverEntityMetadataPacket(PacketSendEvent event);
+    ServerEntityPositionSyncPacket serverEntityPositionSyncPacket(PacketSendEvent event);
+    ServerEntityRelativeMoveAndRotationPacket serverEntityRelativeMoveAndRotationPacket(PacketSendEvent event);
+    ServerEntityRelativeMovePacket serverEntityRelativeMovePacket(PacketSendEvent event);
+    ServerEntityRotationPacket serverEntityRotationPacket(PacketSendEvent event);
+    ServerEntityTeleportPacket serverEntityTeleportPacket(PacketSendEvent event);
+    ServerEntityTeleportPacket serverEntityTeleportPacket(int entityID, ImmutableVector3d position, float yaw, float pitch, boolean onGround);
+    ServerEntityVelocityPacket serverEntityVelocityPacket(PacketSendEvent event);
+    ServerEntityVelocityPacket serverEntityVelocityPacket(int entityID, ImmutableVector3d velocity);
+    ServerPlayerInfoRemovePacket serverPlayerInfoRemovePacket(PacketSendEvent event);
+    ServerSpawnEntityPacket serverSpawnEntityPacket(PacketSendEvent event);
+    ServerSpawnLivingEntityPacket serverSpawnLivingEntityPacket(PacketSendEvent event);
+    ServerSpawnPaintingPacket serverSpawnPaintingPacket(PacketSendEvent event);
+    ServerSpawnPlayerPacket serverSpawnPlayerPacket(PacketSendEvent event);
 
     ServerSetSlotPacket serverSetSlot(PacketSendEvent event);
 }

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityMetadataPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityMetadataPacket.java
@@ -1,5 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.entity.EntityData;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 
@@ -7,7 +8,7 @@ import java.util.List;
 
 public interface ServerEntityMetadataPacket {
     static ServerEntityMetadataPacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverEntityMetadataPacket.from(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityMetadataPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityMetadataPacket.java
@@ -1,6 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.entity.EntityData;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface ServerEntityMetadataPacket {
     static ServerEntityMetadataPacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverEntityMetadataPacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverEntityMetadataPacket(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityPositionSyncPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityPositionSyncPacket.java
@@ -1,12 +1,12 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3d;
 
 public interface ServerEntityPositionSyncPacket {
     static ServerEntityPositionSyncPacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverEntityPositionSyncPacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverEntityPositionSyncPacket(event);
     }
 
     int getId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityPositionSyncPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityPositionSyncPacket.java
@@ -1,11 +1,12 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3d;
 
 public interface ServerEntityPositionSyncPacket {
     static ServerEntityPositionSyncPacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverEntityPositionSyncPacket.from(event);
     }
 
     int getId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRelativeMoveAndRotationPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRelativeMoveAndRotationPacket.java
@@ -1,10 +1,11 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 
 public interface ServerEntityRelativeMoveAndRotationPacket {
     static ServerEntityRelativeMoveAndRotationPacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverEntityRelativeMoveAndRotationPacket.from(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRelativeMoveAndRotationPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRelativeMoveAndRotationPacket.java
@@ -1,11 +1,11 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 
 public interface ServerEntityRelativeMoveAndRotationPacket {
     static ServerEntityRelativeMoveAndRotationPacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverEntityRelativeMoveAndRotationPacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverEntityRelativeMoveAndRotationPacket(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRelativeMovePacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRelativeMovePacket.java
@@ -1,11 +1,11 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 
 public interface ServerEntityRelativeMovePacket {
     static ServerEntityRelativeMovePacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverEntityRelativeMovePacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverEntityRelativeMovePacket(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRelativeMovePacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRelativeMovePacket.java
@@ -1,10 +1,11 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 
 public interface ServerEntityRelativeMovePacket {
     static ServerEntityRelativeMovePacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverEntityRelativeMovePacket.from(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRotationPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRotationPacket.java
@@ -1,10 +1,11 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 
 public interface ServerEntityRotationPacket {
     static ServerEntityRotationPacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverEntityRotationPacket.from(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRotationPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityRotationPacket.java
@@ -1,11 +1,11 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 
 public interface ServerEntityRotationPacket {
     static ServerEntityRotationPacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverEntityRotationPacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverEntityRotationPacket(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityTeleportPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityTeleportPacket.java
@@ -1,6 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.types.SendablePacket;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3d;
@@ -9,11 +9,11 @@ import org.jetbrains.annotations.NotNull;
 public interface ServerEntityTeleportPacket extends SendablePacket {
     static ServerEntityTeleportPacket from(int entityID, ImmutableVector3d position, float yaw, float pitch, boolean onGround) {
 //        return MCPacket.getAPI().packetFactory().serverEntityTeleportPacket(entityID, position, yaw, pitch, onGround);
-        return MCPacket.getAPI().packetFactory().serverEntityTeleportPacket.from(entityID, position, yaw, pitch, onGround);
+        return MCPacket.getAPI().packetFactory().serverEntityTeleportPacket(entityID, position, yaw, pitch, onGround);
     }
 
     static ServerEntityTeleportPacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverEntityTeleportPacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverEntityTeleportPacket(event);
     }
 
     @NotNull ImmutableVector3d getPosition();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityTeleportPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityTeleportPacket.java
@@ -1,5 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.types.SendablePacket;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3d;
@@ -8,11 +9,11 @@ import org.jetbrains.annotations.NotNull;
 public interface ServerEntityTeleportPacket extends SendablePacket {
     static ServerEntityTeleportPacket from(int entityID, ImmutableVector3d position, float yaw, float pitch, boolean onGround) {
 //        return MCPacket.getAPI().packetFactory().serverEntityTeleportPacket(entityID, position, yaw, pitch, onGround);
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverEntityTeleportPacket.from(entityID, position, yaw, pitch, onGround);
     }
 
     static ServerEntityTeleportPacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverEntityTeleportPacket.from(event);
     }
 
     @NotNull ImmutableVector3d getPosition();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityVelocityPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityVelocityPacket.java
@@ -1,16 +1,17 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.types.SendablePacket;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3d;
 
 public interface ServerEntityVelocityPacket extends SendablePacket {
     static ServerEntityVelocityPacket from(int entityID, ImmutableVector3d velocity) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverEntityVelocityPacket.from(entityID, velocity);
     }
 
     static ServerEntityVelocityPacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverEntityVelocityPacket.from(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityVelocityPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerEntityVelocityPacket.java
@@ -1,17 +1,17 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.types.SendablePacket;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3d;
 
 public interface ServerEntityVelocityPacket extends SendablePacket {
     static ServerEntityVelocityPacket from(int entityID, ImmutableVector3d velocity) {
-        return MCPacket.getAPI().packetFactory().serverEntityVelocityPacket.from(entityID, velocity);
+        return MCPacket.getAPI().packetFactory().serverEntityVelocityPacket(entityID, velocity);
     }
 
     static ServerEntityVelocityPacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverEntityVelocityPacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverEntityVelocityPacket(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerPlayerInfoRemovePacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerPlayerInfoRemovePacket.java
@@ -1,5 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 
 import java.util.List;
@@ -7,7 +8,7 @@ import java.util.UUID;
 
 public interface ServerPlayerInfoRemovePacket {
     static ServerPlayerInfoRemovePacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverPlayerInfoRemovePacket.from(event);
     }
 
     List<UUID> getProfileIds();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerPlayerInfoRemovePacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerPlayerInfoRemovePacket.java
@@ -1,6 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 
 import java.util.List;
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public interface ServerPlayerInfoRemovePacket {
     static ServerPlayerInfoRemovePacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverPlayerInfoRemovePacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverPlayerInfoRemovePacket(event);
     }
 
     List<UUID> getProfileIds();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnEntityPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnEntityPacket.java
@@ -1,6 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.entity.PacketEntityType;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3d;
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public interface ServerSpawnEntityPacket {
     static ServerSpawnEntityPacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverSpawnEntityPacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverSpawnEntityPacket(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnEntityPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnEntityPacket.java
@@ -1,5 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.entity.PacketEntityType;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3d;
@@ -9,7 +10,7 @@ import java.util.UUID;
 
 public interface ServerSpawnEntityPacket {
     static ServerSpawnEntityPacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverSpawnEntityPacket.from(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnLivingEntityPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnLivingEntityPacket.java
@@ -1,5 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.entity.EntityData;
 import ac.grim.grimac.api.packet.entity.PacketEntityType;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
@@ -10,7 +11,7 @@ import java.util.UUID;
 
 public interface ServerSpawnLivingEntityPacket {
     static ServerSpawnLivingEntityPacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverSpawnLivingEntityPacket.from(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnLivingEntityPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnLivingEntityPacket.java
@@ -1,6 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.entity.EntityData;
 import ac.grim.grimac.api.packet.entity.PacketEntityType;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
@@ -11,7 +11,7 @@ import java.util.UUID;
 
 public interface ServerSpawnLivingEntityPacket {
     static ServerSpawnLivingEntityPacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverSpawnLivingEntityPacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverSpawnLivingEntityPacket(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnPaintingPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnPaintingPacket.java
@@ -1,6 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3i;
 
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public interface ServerSpawnPaintingPacket {
     static ServerSpawnPaintingPacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverSpawnPaintingPacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverSpawnPaintingPacket(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnPaintingPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnPaintingPacket.java
@@ -1,5 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3i;
 
@@ -7,7 +8,7 @@ import java.util.UUID;
 
 public interface ServerSpawnPaintingPacket {
     static ServerSpawnPaintingPacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverSpawnPaintingPacket.from(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnPlayerPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnPlayerPacket.java
@@ -1,5 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
 
+import ac.grim.grimac.api.packet.MCPacket;
 import ac.grim.grimac.api.packet.entity.EntityData;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3d;
@@ -9,7 +10,7 @@ import java.util.UUID;
 
 public interface ServerSpawnPlayerPacket {
     static ServerSpawnPlayerPacket from(PacketSendEvent event) {
-        return null; // TODO (Packet Rewrite)
+        return MCPacket.getAPI().packetFactory().serverSpawnPlayerPacket.from(event);
     }
 
     int getEntityId();

--- a/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnPlayerPacket.java
+++ b/packet/src/main/java/ac/grim/grimac/api/packet/types/server/play/ServerSpawnPlayerPacket.java
@@ -1,6 +1,6 @@
 package ac.grim.grimac.api.packet.types.server.play;
-
 import ac.grim.grimac.api.packet.MCPacket;
+
 import ac.grim.grimac.api.packet.entity.EntityData;
 import ac.grim.grimac.api.packet.types.event.PacketSendEvent;
 import ac.grim.grimac.api.packet.util.vec.ImmutableVector3d;
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public interface ServerSpawnPlayerPacket {
     static ServerSpawnPlayerPacket from(PacketSendEvent event) {
-        return MCPacket.getAPI().packetFactory().serverSpawnPlayerPacket.from(event);
+        return MCPacket.getAPI().packetFactory().serverSpawnPlayerPacket(event);
     }
 
     int getEntityId();


### PR DESCRIPTION
## Summary
- replace `return null;` placeholders for packet rewrites with calls to `MCPacket.getAPI().packetFactory()`
- add missing MCPacket imports

## Testing
- `./gradlew test` *(fails: No route to host)*